### PR TITLE
Color update

### DIFF
--- a/VolvoWrench/Demo stuff/GoldSource/Verification.cs
+++ b/VolvoWrench/Demo stuff/GoldSource/Verification.cs
@@ -29,6 +29,7 @@ namespace VolvoWrench.Demo_Stuff.GoldSource
         public Verification()
         {
             InitializeComponent();
+            this.Text = "Verification Scriptless";
             DemopathList = new List<string>();
             this.mrtb.DragDrop += Verification_DragDrop;
             this.mrtb.DragEnter += Verification_DragEnter;

--- a/VolvoWrench/Demo stuff/GoldSource/Verification.cs
+++ b/VolvoWrench/Demo stuff/GoldSource/Verification.cs
@@ -151,6 +151,10 @@ Human readable time:        {TimeSpan.FromSeconds(Df.Sum(x => x.Value.GsDemoInfo
                     mrtb.AppendText(Path.GetFileName(dem.Key) + " -> " + dem.Value.GsDemoInfo.Header.MapName);
                     mrtb.AppendText("\nBXTData:");
                     mrtb.AppendText("\n" + ParseBxtData(dem));
+                    mrtb.Invalidate();
+                    mrtb.Update();
+                    mrtb.Refresh();
+                    Application.DoEvents();
                 }
             }
         }
@@ -917,8 +921,8 @@ Human readable time:        {TimeSpan.FromSeconds(Df.Sum(x => x.Value.GsDemoInfo
                     {
                         case Bxt.RuntimeDataType.VERSION_INFO:
                             {
-                                ret +=("\t" + "BXT Version: " + ((((Bxt.VersionInfo)t.Value).bxt_version == bxtVersion) ? "Latest (November 11th 2024)" : ("INVALID=" + ((Bxt.VersionInfo)t.Value).bxt_version)) + "\n");
-                                ret +=("\t" + "Game Version: " + ((Bxt.VersionInfo)t.Value).build_number + ", Game Directory: " + gamedir + "\n");
+                                AppendColored(mrtb, "\t" + "BXT Version: " + ((((Bxt.VersionInfo)t.Value).bxt_version == bxtVersion) ? "Latest (November 11th 2024)" : ("INVALID=" + ((Bxt.VersionInfo)t.Value).bxt_version)) + "\n");
+                                AppendColored(mrtb, "\t" + "Game Version: " + ((Bxt.VersionInfo)t.Value).build_number + ", Game Directory: " + gamedir + "\n");
                                 datanode.Nodes.Add(new TreeNode("Version info")
                                 {
                                     ForeColor = Color.PaleVioletRed,
@@ -934,7 +938,7 @@ Human readable time:        {TimeSpan.FromSeconds(Df.Sum(x => x.Value.GsDemoInfo
                             {
                                 foreach (var cvar in ((Bxt.CVarValues)t.Value).CVars.Where(cvar => cvarRules.ContainsKey(cvar.Key.ToUpper())).Where(cvar => cvarRules[cvar.Key.ToUpper()] != cvar.Value.ToUpper()))
                                 {
-                                    ret +=("\t" + "Illegal Cvar: " + cvar.Key + " " + cvar.Value + "\n");
+                                    AppendColored(mrtb, "\t" + "Illegal Cvar: " + cvar.Key + " " + cvar.Value + "\n");
                                 }
                                 var cvarnode = new TreeNode("Cvars [" + ((Bxt.CVarValues)t.Value).CVars.Count + "]")
                                 {
@@ -950,7 +954,7 @@ Human readable time:        {TimeSpan.FromSeconds(Df.Sum(x => x.Value.GsDemoInfo
                             {
                                 if (i+1 == info.Value.GsDemoInfo.IncludedBXtData.Count)
                                 {
-                                    ret +=("\t" + "Demo bxt time: " + ((Bxt.Time)t.Value).ToString() + " — Frame: " + i + "\n");
+                                    AppendColored(mrtb, "\t" + "Demo bxt time: " + ((Bxt.Time)t.Value).ToString() + " — Frame: " + i + "\n");
                                 }
                                 datanode.Nodes.Add(new TreeNode("Time: " + ((Bxt.Time)t.Value).ToString())
                                 {
@@ -971,7 +975,7 @@ Human readable time:        {TimeSpan.FromSeconds(Df.Sum(x => x.Value.GsDemoInfo
                                     dm++;
                                 if (command.ToUpper().Contains(";"))
                                 {
-                                    ret +=("\t" + "Possible script: " + command + " — Frame: " + i + "\n");
+                                    AppendColored(mrtb, "\t" + "Possible script: " + command + " — Frame: " + i + "\n");
                                 }
                                 datanode.Nodes.Add(new TreeNode("Bound command: " + command)
                                 {
@@ -991,7 +995,7 @@ Human readable time:        {TimeSpan.FromSeconds(Df.Sum(x => x.Value.GsDemoInfo
                             }
                         case Bxt.RuntimeDataType.SCRIPT_EXECUTION:
                             {
-                                ret +=("\t" + "Config execution: " + ((Bxt.ScriptExecution)t.Value).filename + " — Frame: " + i + "\n");
+                                AppendColored(mrtb, "\t" + "Config execution: " + ((Bxt.ScriptExecution)t.Value).filename + " — Frame: " + i + "\n");
                                 //Directory.CreateDirectory(Environment.GetFolderPath(Environment.SpecialFolder.Desktop) + "\\verification cfgs\\");
                                 //File.WriteAllText(Environment.GetFolderPath(Environment.SpecialFolder.Desktop) + "\\verification cfgs\\" + ((Bxt.ScriptExecution)t.Value).filename, ((Bxt.ScriptExecution)t.Value).contents);
                                 datanode.Nodes.Add(new TreeNode("Script: " + ((Bxt.ScriptExecution)t.Value).filename)
@@ -1048,7 +1052,7 @@ Human readable time:        {TimeSpan.FromSeconds(Df.Sum(x => x.Value.GsDemoInfo
                                   || command.ToUpper().Contains("_CROSS")
                                   || command.ToUpper().Contains("_VIEWMODEL")))
                                 {
-                                    ret +=("\t" + "Disallowed BXT command: " + command + " — Frame: " + i + "\n");
+                                    AppendColored(mrtb, "\t" + "Disallowed BXT command: " + command + " — Frame: " + i + "\n");
                                 }
                                 datanode.Nodes.Add(new TreeNode("Command: " + command)
                                 {
@@ -1078,7 +1082,7 @@ Human readable time:        {TimeSpan.FromSeconds(Df.Sum(x => x.Value.GsDemoInfo
                                   || command.ToUpper().Contains("CAM")
                                   || command.ToUpper().Contains("JOY"))
                                 {
-                                    ret +=("\t" + "Disallowed: " + command + " — Frame: " + i + "\n");
+                                    AppendColored(mrtb, "\t" + "Disallowed: " + command + " — Frame: " + i + "\n");
                                 }
                                 if ((command.ToUpper().Contains("SV_")
                                   && !command.ToUpper().Contains("AIM"))
@@ -1116,7 +1120,7 @@ Human readable time:        {TimeSpan.FromSeconds(Df.Sum(x => x.Value.GsDemoInfo
                         case Bxt.RuntimeDataType.CUSTOM_TRIGGER_COMMAND:
                             {
                                 var trigger = (Bxt.CustomTriggerCommand)t.Value;
-                                ret +=("\t" + $"Custom trigger X1:{trigger.corner_max.X} Y1:{trigger.corner_max.Y} Z1:{trigger.corner_max.Z} X2:{trigger.corner_min.X} Y2:{trigger.corner_min.Y} Z2:{trigger.corner_min.Z}" + " — Frame: " + i + "\n");
+                                AppendColored(mrtb, "\t" + $"Custom trigger X1:{trigger.corner_max.X} Y1:{trigger.corner_max.Y} Z1:{trigger.corner_max.Z} X2:{trigger.corner_min.X} Y2:{trigger.corner_min.Y} Z2:{trigger.corner_min.Z}" + " — Frame: " + i + "\n");
                                 datanode.Nodes.Add(new TreeNode($"Custom trigger X1:{trigger.corner_max.X} Y1:{trigger.corner_max.Y} Z1:{trigger.corner_max.Z} X2:{trigger.corner_min.X} Y2:{trigger.corner_min.Y} Z2:{trigger.corner_min.Z}")
                                 {
                                     ForeColor = Color.Orange,
@@ -1141,7 +1145,7 @@ Human readable time:        {TimeSpan.FromSeconds(Df.Sum(x => x.Value.GsDemoInfo
                         case Bxt.RuntimeDataType.SPLIT_MARKER:
                             {
                                 var split = (Bxt.SplitMarker)t.Value;
-                                ret +=("\t" + $"Split trigger X1:{split.corner_max.X} Y1:{split.corner_max.Y} Z1:{split.corner_max.Z} X2:{split.corner_min.X} Y2:{split.corner_min.Y} Z2:{split.corner_min.Z}" + " — Frame: " + i + "\n");
+                                AppendColored(mrtb, "\t" + $"Split trigger X1:{split.corner_max.X} Y1:{split.corner_max.Y} Z1:{split.corner_max.Z} X2:{split.corner_min.X} Y2:{split.corner_min.Y} Z2:{split.corner_min.Z}" + " — Frame: " + i + "\n");
                                 datanode.Nodes.Add(new TreeNode($"Split trigger X1:{split.corner_max.X} Y1:{split.corner_max.Y} Z1:{split.corner_max.Z} X2:{split.corner_min.X} Y2:{split.corner_min.Y} Z2:{split.corner_min.Z}")
                                 {
                                     ForeColor = Color.Orange,
@@ -1184,6 +1188,19 @@ Human readable time:        {TimeSpan.FromSeconds(Df.Sum(x => x.Value.GsDemoInfo
             var dropfiles = (string[]) e.Data.GetData(DataFormats.FileDrop);
             Verify(dropfiles);
             e.Effect = DragDropEffects.None;
+        }
+
+        private void AppendColored(RichTextBox box, string text, Color color)
+        {
+            box.SelectionStart = box.TextLength;
+            box.SelectionColor = color;
+            box.AppendText(text);
+            box.SelectionColor = box.ForeColor;    // reset
+        }
+
+        private void AppendColored(RichTextBox box, string text)
+        {
+            AppendColored(box, text, box.ForeColor);
         }
     }
 }

--- a/VolvoWrench/Demo stuff/GoldSource/Verification.cs
+++ b/VolvoWrench/Demo stuff/GoldSource/Verification.cs
@@ -149,8 +149,9 @@ Human readable time:        {TimeSpan.FromSeconds(Df.Sum(x => x.Value.GsDemoInfo
                         }
                     }
                     mrtb.AppendText(Path.GetFileName(dem.Key) + " -> " + dem.Value.GsDemoInfo.Header.MapName);
-                    mrtb.AppendText("\nBXTData:");
-                    mrtb.AppendText("\n" + ParseBxtData(dem));
+                    mrtb.AppendText("\nBXTData:\n");
+                    ParseBxtData(dem);
+                    mrtb.AppendText("\n");
                     mrtb.Invalidate();
                     mrtb.Update();
                     mrtb.Refresh();
@@ -163,9 +164,8 @@ Human readable time:        {TimeSpan.FromSeconds(Df.Sum(x => x.Value.GsDemoInfo
         /// Parses the bxt data into treenodes
         /// </summary>
         /// <param name="Infos"></param>
-        public string ParseBxtData(KeyValuePair<string, CrossParseResult> info)
+        public void ParseBxtData(KeyValuePair<string, CrossParseResult> info)
         {
-            string ret = "\n";
             const string bxtVersion = "cbc496b1ba7f6c242a961c33f16d3b5741371dd6-CLEAN based on nov-11-2024";
             var cvarRules = new Dictionary<string, string>()
             {
@@ -938,7 +938,7 @@ Human readable time:        {TimeSpan.FromSeconds(Df.Sum(x => x.Value.GsDemoInfo
                             {
                                 foreach (var cvar in ((Bxt.CVarValues)t.Value).CVars.Where(cvar => cvarRules.ContainsKey(cvar.Key.ToUpper())).Where(cvar => cvarRules[cvar.Key.ToUpper()] != cvar.Value.ToUpper()))
                                 {
-                                    AppendColored(mrtb, "\t" + "Illegal Cvar: " + cvar.Key + " " + cvar.Value + "\n");
+                                    AppendColored(mrtb, "\t" + "Illegal Cvar: " + cvar.Key + " " + cvar.Value + "\n", Color.Red);
                                 }
                                 var cvarnode = new TreeNode("Cvars [" + ((Bxt.CVarValues)t.Value).CVars.Count + "]")
                                 {
@@ -988,7 +988,7 @@ Human readable time:        {TimeSpan.FromSeconds(Df.Sum(x => x.Value.GsDemoInfo
                                 string aliasCommand = ((Bxt.AliasExpansion)t.Value).command.Trim();
                                 if (aliasCommand.ToUpper().Contains(";"))
                                 {
-                                    ret += ("\t" + "Alias [" + ((Bxt.AliasExpansion)t.Value).name + "]: " + aliasCommand + " — Frame: " + i + "\n");
+                                    AppendColored(mrtb, "\t" + "Alias [" + ((Bxt.AliasExpansion)t.Value).name + "]: " + aliasCommand + " — Frame: " + i + "\n");
                                 }
                                 datanode.Nodes.Add(new TreeNode("Alias [" + ((Bxt.AliasExpansion)t.Value).name + "]: " + aliasCommand) { ForeColor = Color.LightCyan });
                                 break;
@@ -1014,28 +1014,28 @@ Human readable time:        {TimeSpan.FromSeconds(Df.Sum(x => x.Value.GsDemoInfo
                                 if (command.ToUpper().Contains("+JUMP"))
                                 {
                                     if (jp == 0)
-                                        ret += ("\t" + "Possible autojump: " + command + " — Frame: " + i + "\n");
+                                        AppendColored(mrtb, "\t" + "Possible autojump: " + command + " — Frame: " + i + "\n");
                                     else
                                         jp--;
                                 }
                                 if (command.ToUpper().Contains("-JUMP"))
                                 {
                                     if (jm == 0)
-                                        ret += ("\t" + "Possible autojump: " + command + " — Frame: " + i + "\n");
+                                        AppendColored(mrtb, "\t" + "Possible autojump: " + command + " — Frame: " + i + "\n");
                                     else
                                         jm--;
                                 }
                                 if (command.ToUpper().Contains("+DUCK"))
                                 {
                                     if (dp == 0)
-                                        ret += ("\t" + "Possible ducktap: " + command + " — Frame: " + i + "\n");
+                                        AppendColored(mrtb, "\t" + "Possible ducktap: " + command + " — Frame: " + i + "\n");
                                     else
                                         dp--;
                                 }
                                 if (command.ToUpper().Contains("-DUCK"))
                                 {
                                     if (dm == 0)
-                                        ret += ("\t" + "Possible ducktap: " + command + " — Frame: " + i + "\n");
+                                        AppendColored(mrtb, "\t" + "Possible ducktap: " + command + " — Frame: " + i + "\n");
                                     else
                                         dm--;
                                 }
@@ -1052,7 +1052,7 @@ Human readable time:        {TimeSpan.FromSeconds(Df.Sum(x => x.Value.GsDemoInfo
                                   || command.ToUpper().Contains("_CROSS")
                                   || command.ToUpper().Contains("_VIEWMODEL")))
                                 {
-                                    AppendColored(mrtb, "\t" + "Disallowed BXT command: " + command + " — Frame: " + i + "\n");
+                                    AppendColored(mrtb, "\t" + "Disallowed BXT command: " + command + " — Frame: " + i + "\n", Color.Red);
                                 }
                                 datanode.Nodes.Add(new TreeNode("Command: " + command)
                                 {
@@ -1060,7 +1060,7 @@ Human readable time:        {TimeSpan.FromSeconds(Df.Sum(x => x.Value.GsDemoInfo
                                 });
                                 if (command.ToUpper().StartsWith("LOAD"))
                                 {
-                                    ret += ("\t" + command + "\n");
+                                    AppendColored(mrtb, "\t" + command + "\n");
                                 }
                                 if (command.ToUpper().Contains("HOST_")
                                   || command.ToUpper().Contains("SK_")
@@ -1082,7 +1082,7 @@ Human readable time:        {TimeSpan.FromSeconds(Df.Sum(x => x.Value.GsDemoInfo
                                   || command.ToUpper().Contains("CAM")
                                   || command.ToUpper().Contains("JOY"))
                                 {
-                                    AppendColored(mrtb, "\t" + "Disallowed: " + command + " — Frame: " + i + "\n");
+                                    AppendColored(mrtb, "\t" + "Disallowed: " + command + " — Frame: " + i + "\n", Color.Red);
                                 }
                                 if ((command.ToUpper().Contains("SV_")
                                   && !command.ToUpper().Contains("AIM"))
@@ -1100,7 +1100,7 @@ Human readable time:        {TimeSpan.FromSeconds(Df.Sum(x => x.Value.GsDemoInfo
 
                                   || command.ToUpper().StartsWith("STAT"))
                                 {
-                                    ret += ("\t" + "Probably disallowed ¯\\_(ツ)_/¯: " + command + " — Frame: " + i + "\n");
+                                    AppendColored(mrtb, "\t" + "Probably disallowed ¯\\_(ツ)_/¯: " + command + " — Frame: " + i + "\n");
                                 }
                                 break;
                             }
@@ -1132,7 +1132,7 @@ Human readable time:        {TimeSpan.FromSeconds(Df.Sum(x => x.Value.GsDemoInfo
                             {
                                 if (((Bxt.Edicts)t.Value).edicts > 900)
                                 {
-                                    ret += ("\t" + "Max edicts value is higher than 900: " + ((Bxt.Edicts)t.Value).edicts + "\n");
+                                    AppendColored(mrtb, "\t" + "Max edicts value is higher than 900: " + ((Bxt.Edicts)t.Value).edicts + "\n", Color.Red);
                                 }
                                 datanode.Nodes.Add(new TreeNode("Max edicts: " + ((Bxt.Edicts)t.Value).edicts) { ForeColor = Color.Violet });
                                 break;
@@ -1159,7 +1159,7 @@ Human readable time:        {TimeSpan.FromSeconds(Df.Sum(x => x.Value.GsDemoInfo
                                 bool bigMap = (bxtFlags & 1) != 0;
                                 if (bigMap)
                                 {
-                                    ret += ("\tThis runner has used bxt_enable_big_map and didn't restart the game before the run. This command is not intended for RTA leaderboard runs.\n");
+                                    AppendColored(mrtb, "\tThis runner has used bxt_enable_big_map and didn't restart the game before the run. This command is not intended for RTA leaderboard runs.\n", Color.Red);
                                 }
                                 datanode.Nodes.Add(new TreeNode("BXT Flags: " + bxtFlags) { ForeColor = Color.LightSalmon });
                                 break;
@@ -1174,8 +1174,6 @@ Human readable time:        {TimeSpan.FromSeconds(Df.Sum(x => x.Value.GsDemoInfo
                 demonode.Nodes.Add(datanode);
             }
             BXTTreeView.Nodes.Add(demonode);
-            ret += "\n";
-            return ret;
         }
 
         private void Verification_DragEnter(object sender, DragEventArgs e)

--- a/VolvoWrench/Demo stuff/GoldSource/Verification.cs
+++ b/VolvoWrench/Demo stuff/GoldSource/Verification.cs
@@ -1061,7 +1061,15 @@ Human readable time:        {TimeSpan.FromSeconds(Df.Sum(x => x.Value.GsDemoInfo
                                 });
                                 if (command.ToUpper().StartsWith("LOAD"))
                                 {
-                                    AppendColored(mrtb, "\t" + command + "\n");
+                                    string loadName = command.Substring(4).ToUpper().Trim();
+                                    if(loadName == "QUICK" || loadName == "HARD" || loadName == "AUTOSAVE")
+                                    {
+                                        AppendColored(mrtb, "\t" + command + "\n");
+                                    }
+                                    else
+                                    {
+                                        AppendColored(mrtb, "\t" + command + "\n", Color.Yellow);
+                                    }
                                 }
                                 if (command.ToUpper().Contains("HOST_")
                                   || command.ToUpper().Contains("SK_")


### PR DESCRIPTION
- Scriptless window title
- Refresh the text window after each demo is processed, I consider this preferable to keeping the window blank until completion.
- Highlight illegal lines in red. Instead of building a large ret string in ParseBxtData, draw each line individually to allow coloring.
- color load names that are not quick, autosave, or hard