### PR TITLE
More HL100

### DIFF
--- a/VolvoWrench/Demo stuff/GoldSource/Verification.cs
+++ b/VolvoWrench/Demo stuff/GoldSource/Verification.cs
@@ -37,12 +37,10 @@ namespace VolvoWrench.Demo_Stuff.GoldSource
         /// <summary>
         ///     Dictionaries related to HL100 kill counting
         /// </summary>
-        // Kill Number, UUID, Monster Type
+        // Kill Number : UUID, Monster Type, Demo File
         private Dictionary<int, (string, string, string)> MonsterTypeKillByNumber = new Dictionary<int, (string, string, string)>();
-        // Map, UUID, Monster Type
+        // Map : [ UUID, Monster Type, Demo File ]
         private Dictionary<string, List<(string, string, string)>> MonsterTypeKillByMap = new Dictionary<string, List<(string, string, string)>>();
-        // Map, UUID, Monster Name
-        private Dictionary<string, List<(string, string, string)>> MonsterNameKillByMap = new Dictionary<string, List<(string, string, string)>>();
 
         /// <summary>
         ///     Default constructor
@@ -139,24 +137,659 @@ namespace VolvoWrench.Demo_Stuff.GoldSource
         /// <param name="textBuffer">Verification output log</param>
         public void VerifyHl100Kills(string[] files, ColoredTextBuffer textBuffer)
         {
-            // Verify they got exactly 944 kills
-            for (int i = 1; i <= 944; i++)
+            bool hasErrors = false;
+            bool hasWarnings = false;
+            const int totalKills = 944;
+
+            // Verify they got exactly totalKills kills
+            for (int i = 1; i <= totalKills; i++)
             {
                 if (!MonsterTypeKillByNumber.ContainsKey(i))
                 {
-                    // Add error to last demo for missing kill
-                    string err = "HL100: Missing kill #" + i + "\n";
-                    Df[files.Last()].GsDemoInfo.ParsingErrors.Add(err);
-                    textBuffer.Append(err, Color.Red);
+                    textBuffer.Append("HL100: Missing kill #" + i + "\n", Color.Yellow);
+                    hasWarnings = true;
                 }
             }
 
-            // Verify the last kill is Nihilanth
-            if (!MonsterTypeKillByNumber.ContainsKey(944) || MonsterTypeKillByNumber[944].Item2 != "monster_nihilanth")
+            if (MonsterTypeKillByNumber.Count() > totalKills)
             {
-                string err = "HL100: Last kill is not nihilanth!\n";
+                // Add error to last demo for extra kills
+                string err = "HL100: Extra kills in run! There should only be " + totalKills + ".\n";
                 Df[files.Last()].GsDemoInfo.ParsingErrors.Add(err);
                 textBuffer.Append(err, Color.Red);
+                hasErrors = true;
+            }
+
+            // Verify the last kill is Nihilanth
+            if (!MonsterTypeKillByNumber.ContainsKey(totalKills) || MonsterTypeKillByNumber[totalKills].Item2 != "monster_nihilanth")
+            {
+                // Add error to last demo for missing kill
+                string err = "HL100: Last kill is not nihilanth or there is no " + totalKills + "th kill!\n";
+                Df[files.Last()].GsDemoInfo.ParsingErrors.Add(err);
+                textBuffer.Append(err, Color.Red);
+                hasErrors = true;
+            }
+            else
+            {
+                textBuffer.Append("\nHL100: Got 944 kills with Nihilanth as the final kill.\n\n", Color.Green);
+            }
+
+            Dictionary<string, Dictionary<string, int>> referenceMonsterCountsByMap = new Dictionary<string, Dictionary<string, int>>
+            {
+                { "c1a1", new Dictionary<string, int>
+                    {
+                        {"monster_headcrab", 1},
+                        {"monster_zombie", 2},
+                    }
+                },
+                { "c1a0c", new Dictionary<string, int>
+                    {
+                        {"monster_headcrab", 1},
+                    }
+                },
+                { "c1a1a", new Dictionary<string, int>
+                    {
+                        {"monster_headcrab", 1},
+                        {"monster_zombie", 2},
+                    }
+                },
+                { "c1a1f", new Dictionary<string, int>
+                    {
+                        {"monster_headcrab", 5},
+                        {"monster_zombie", 2},
+                    }
+                },
+                { "c1a1b", new Dictionary<string, int>
+                    {
+                        {"monster_houndeye", 4},
+                        {"monster_headcrab", 5},
+                        {"monster_zombie", 3},
+                        {"monster_alien_slave", 1},
+                    }
+                },
+                { "c1a1c", new Dictionary<string, int>
+                    {
+                        {"monster_headcrab", 11},
+                        {"monster_houndeye", 1},
+                        {"monster_bullchicken", 2},
+                        {"monster_barnacle", 7},
+                    }
+                },
+                { "c1a2", new Dictionary<string, int>
+                    {
+                        {"monster_headcrab", 21},
+                        {"monster_barnacle", 3},
+                        {"monster_zombie", 1},
+                        {"monster_miniturret", 1},
+                    }
+                },
+                { "c1a2d", new Dictionary<string, int>
+                    {
+                        {"monster_headcrab", 2},
+                        {"monster_zombie", 1},
+                    }
+                },
+                { "c1a2a", new Dictionary<string, int>
+                    {
+                        {"monster_headcrab", 10},
+                        {"monster_alien_slave", 12},
+                        {"monster_barnacle", 2},
+                        {"monster_miniturret", 1},
+                        {"monster_zombie", 1},
+                    }
+                },
+                { "c1a2b", new Dictionary<string, int>
+                    {
+                        {"monster_headcrab", 13},
+                        {"monster_bullchicken", 1},
+                        {"monster_alien_slave", 2},
+                        {"monster_zombie", 4},
+                    }
+                },
+                { "c1a2c", new Dictionary<string, int>
+                    {
+                        {"monster_zombie", 2},
+                        {"monster_bullchicken", 2},
+                        {"monster_headcrab", 7},
+                        {"monster_barnacle", 4},
+                    }
+                },
+                { "c1a3", new Dictionary<string, int>
+                    {
+                        {"monster_zombie", 1},
+                        {"monster_headcrab", 4},
+                        {"monster_sentry", 5},
+                        {"monster_alien_slave", 2},
+                        {"monster_human_grunt", 2},
+                    }
+                },
+                { "c1a3d", new Dictionary<string, int>
+                    {
+                        {"monster_sentry", 2},
+                        {"monster_human_grunt", 1},
+                    }
+                },
+                { "c1a3a", new Dictionary<string, int>
+                    {
+                        {"monster_human_grunt", 10},
+                        {"monster_barnacle", 11},
+                        {"monster_sentry", 3},
+                    }
+                },
+                { "c1a3b", new Dictionary<string, int>
+                    {
+                        {"monster_human_grunt", 4},
+                        {"monster_osprey", 1},
+                    }
+                },
+                { "c1a3c", new Dictionary<string, int>
+                    {
+                        {"monster_human_grunt", 2},
+                        {"monster_osprey", 1},
+                    }
+                },
+                { "c1a4", new Dictionary<string, int>
+                    {
+                        {"monster_headcrab", 7},
+                        {"monster_bullchicken", 5},
+                        {"monster_zombie", 1},
+                        {"monster_houndeye", 5},
+                    }
+                },
+                { "c1a4k", new Dictionary<string, int>
+                    {
+                        {"monster_bullchicken", 4},
+                    }
+                },
+                { "c1a4b", new Dictionary<string, int>
+                    {
+                        {"monster_bullchicken", 2},
+                        {"monster_houndeye", 6},
+                        {"monster_headcrab", 2},
+                        {"monster_zombie", 1},
+                    }
+                },
+                { "c1a4i", new Dictionary<string, int>
+                    {
+                        {"monster_zombie", 2},
+                        {"monster_barnacle", 2},
+                        {"monster_tentacle", 3},
+                    }
+                },
+                { "c1a4f", new Dictionary<string, int>
+                    {
+                        {"monster_bullchicken", 2},
+                        {"monster_houndeye", 3},
+                        {"monster_barnacle", 3},
+                        {"monster_zombie", 1},
+                    }
+                },
+                { "c1a4d", new Dictionary<string, int>
+                    {
+                        {"monster_zombie", 6},
+                        {"monster_bullchicken", 2},
+                        {"monster_headcrab", 1},
+                    }
+                },
+                { "c1a4e", new Dictionary<string, int>
+                    {
+                        {"monster_zombie", 2},
+                        {"monster_headcrab", 3},
+                    }
+                },
+                { "c1a4j", new Dictionary<string, int>
+                    {
+                        {"monster_headcrab", 1},
+                    }
+                },
+                { "c2a1", new Dictionary<string, int>
+                    {
+                        {"monster_human_grunt", 2},
+                        {"monster_alien_slave", 7},
+                        {"monster_headcrab", 9},
+                        {"monster_gargantua", 1},
+                    }
+                },
+                { "c2a1b", new Dictionary<string, int>
+                    {
+                        {"monster_alien_slave", 2},
+                        {"monster_bullchicken", 1},
+                        {"monster_human_grunt", 3},
+                        {"monster_sentry", 1},
+                    }
+                },
+                { "c2a1a", new Dictionary<string, int>
+                    {
+                        {"monster_human_grunt", 14},
+                        {"monster_headcrab", 3},
+                        {"monster_houndeye", 5},
+                        {"monster_zombie", 1},
+                    }
+                },
+                { "c2a2", new Dictionary<string, int>
+                    {
+                        {"monster_barnacle", 4},
+                    }
+                },
+                { "c2a2a", new Dictionary<string, int>
+                    {
+                        {"monster_houndeye", 5},
+                        {"monster_headcrab", 2},
+                        {"monster_bullchicken", 3},
+                        {"monster_sentry", 1},
+                        {"monster_barnacle", 4},
+                    }
+                },
+                { "c2a2b2", new Dictionary<string, int>
+                    {
+                        {"monster_bullchicken", 4},
+                        {"monster_human_grunt", 1},
+                        {"monster_headcrab", 7},
+                        {"monster_houndeye", 3},
+                        {"monster_barnacle", 3},
+                    }
+                },
+                { "c2a2b1", new Dictionary<string, int>
+                    {
+                        {"monster_human_grunt", 11},
+                        {"monster_headcrab", 2},
+                        {"monster_alien_slave", 4},
+                    }
+                },
+                { "c2a2c", new Dictionary<string, int>
+                    {
+                        {"monster_alien_slave", 8},
+                        {"monster_human_grunt", 5},
+                        {"monster_headcrab", 1},
+                    }
+                },
+                { "c2a2d", new Dictionary<string, int>
+                    {
+                        {"monster_human_grunt", 7},
+                        {"monster_alien_slave", 4},
+                        {"monster_headcrab", 6},
+                        {"monster_bullchicken", 3},
+                        {"monster_sentry", 3},
+                        {"monster_barnacle", 1},
+                    }
+                },
+                { "c2a2e", new Dictionary<string, int>
+                    {
+                        {"monster_human_grunt", 11},
+                        {"monster_alien_slave", 6},
+                        {"monster_headcrab", 2},
+                    }
+                },
+                { "c2a2f", new Dictionary<string, int>
+                    {
+                        {"monster_human_grunt", 3},
+                        {"monster_sentry", 2},
+                    }
+                },
+                { "c2a2g", new Dictionary<string, int>
+                    {
+                        {"monster_sentry", 4},
+                        {"monster_zombie", 2},
+                        {"monster_human_grunt", 4},
+                        {"func_breakable", 1},
+                    }
+                },
+                { "c2a2h", new Dictionary<string, int>
+                    {
+                        {"monster_human_grunt", 5},
+                    }
+                },
+                { "c2a3", new Dictionary<string, int>
+                    {
+                        {"monster_human_grunt", 3},
+                        {"monster_zombie", 2},
+                    }
+                },
+                { "c2a3a", new Dictionary<string, int>
+                    {
+                        {"monster_ichthyosaur", 1},
+                        {"monster_barnacle", 7},
+                    }
+                },
+                { "c2a3b", new Dictionary<string, int>
+                    {
+                        {"monster_barnacle", 6},
+                        {"monster_alien_slave", 3},
+                        {"monster_ichthyosaur", 2},
+                        {"monster_bullchicken", 3},
+                        {"monster_headcrab", 1},
+                    }
+                },
+                { "c2a3c", new Dictionary<string, int>
+                    {
+                        {"monster_alien_slave", 6},
+                        {"monster_headcrab", 6},
+                    }
+                },
+                { "c2a3d", new Dictionary<string, int>
+                    {
+                        {"monster_alien_slave", 4},
+                        {"monster_human_assassin", 3},
+                    }
+                },
+                { "c2a4", new Dictionary<string, int>
+                    {
+                        {"monster_headcrab", 2},
+                    }
+                },
+                { "c2a4a", new Dictionary<string, int>
+                    {
+                        {"monster_headcrab", 4},
+                        {"monster_barnacle", 4},
+                    }
+                },
+                { "c2a4b", new Dictionary<string, int>
+                    {
+                        {"monster_bullchicken", 4},
+                    }
+                },
+                { "c2a4c", new Dictionary<string, int>
+                    {
+                        {"monster_headcrab", 4},
+                        {"monster_bullchicken", 1},
+                        {"monster_barnacle", 6},
+                    }
+                },
+                { "c2a4d", new Dictionary<string, int>
+                    {
+                        {"monster_houndeye", 5},
+                        {"monster_alien_grunt", 1},
+                        {"monster_headcrab", 5},
+                        {"monster_human_grunt", 1},
+                    }
+                },
+                { "c2a4e", new Dictionary<string, int>
+                    {
+                        {"monster_human_grunt", 11},
+                        {"monster_headcrab", 14},
+                        {"monster_alien_grunt", 2},
+                    }
+                },
+                { "c2a4f", new Dictionary<string, int>
+                    {
+                        {"monster_bullchicken", 3},
+                        {"monster_human_grunt", 4},
+                        {"monster_houndeye", 4},
+                    }
+                },
+                { "c2a4g", new Dictionary<string, int>
+                    {
+                        {"monster_human_grunt", 1},
+                        {"monster_sentry", 2},
+                    }
+                },
+                { "c2a5", new Dictionary<string, int>
+                    {
+                        {"monster_human_grunt", 5},
+                        {"monster_alien_slave", 1},
+                        {"monster_apache", 1},
+                        {"func_breakable", 1},
+                        {"monster_ichthyosaur", 1},
+                    }
+                },
+                { "c2a5w", new Dictionary<string, int>
+                    {
+                        {"monster_apache", 1},
+                        {"monster_headcrab", 3},
+                        {"monster_houndeye", 1},
+                        {"monster_human_grunt", 4},
+                    }
+                },
+                { "c2a5x", new Dictionary<string, int>
+                    {
+                        {"monster_headcrab", 6},
+                    }
+                },
+                { "c2a5a", new Dictionary<string, int>
+                    {
+                        {"monster_sentry", 1},
+                        {"monster_human_grunt", 5},
+                        {"monster_apache", 1},
+                        {"monster_headcrab", 1},
+                    }
+                },
+                { "c2a5b", new Dictionary<string, int>
+                    {
+                        {"monster_human_grunt", 9},
+                        {"func_breakable", 2},
+                    }
+                },
+                { "c2a5c", new Dictionary<string, int>
+                    {
+                        {"monster_alien_grunt", 1},
+                        {"monster_alien_slave", 1},
+                        {"func_breakable", 2},
+                    }
+                },
+                { "c2a5d", new Dictionary<string, int>
+                    {
+                        {"monster_headcrab", 3},
+                        {"monster_human_grunt", 2},
+                    }
+                },
+                { "c2a5e", new Dictionary<string, int>
+                    {
+                        {"monster_human_grunt", 10},
+                        {"monster_sentry", 1},
+                        {"func_breakable", 2},
+                        {"monster_alien_grunt", 8},
+                        {"monster_osprey", 1},
+                    }
+                },
+                { "c2a5f", new Dictionary<string, int>
+                    {
+                        {"monster_human_grunt", 21},
+                        {"monster_alien_slave", 11},
+                        {"monster_alien_grunt", 10},
+                        {"monster_headcrab", 5},
+                    }
+                },
+                { "c2a5g", new Dictionary<string, int>
+                    {
+                        {"monster_human_grunt", 2},
+                        {"monster_gargantua", 1},
+                    }
+                },
+                { "c3a1", new Dictionary<string, int>
+                    {
+                        {"monster_alien_grunt", 7},
+                        {"monster_alien_slave", 5},
+                        {"monster_turret", 1},
+                        {"monster_barnacle", 1},
+                    }
+                },
+                { "c3a1a", new Dictionary<string, int>
+                    {
+                        {"monster_headcrab", 5},
+                        {"monster_sentry", 3},
+                        {"monster_barnacle", 4},
+                        {"monster_ichthyosaur", 1},
+                        {"monster_human_grunt", 3},
+                        {"func_breakable", 1},
+                    }
+                },
+                { "c3a1b", new Dictionary<string, int>
+                    {
+                        {"monster_human_grunt", 5},
+                        {"monster_alien_grunt", 7},
+                        {"monster_alien_slave", 3},
+                        {"func_breakable", 1},
+                    }
+                },
+                { "c3a2e", new Dictionary<string, int>
+                    {
+                        {"monster_headcrab", 6},
+                        {"monster_bullchicken", 1},
+                        {"monster_human_assassin", 4},
+                    }
+                },
+                { "c3a2", new Dictionary<string, int>
+                    {
+                        {"monster_alien_grunt", 4},
+                        {"monster_headcrab", 6},
+                        {"monster_bullchicken", 1},
+                    }
+                },
+                { "c3a2a", new Dictionary<string, int>
+                    {
+                        {"monster_barnacle", 6},
+                        {"monster_alien_grunt", 11},
+                        {"monster_headcrab", 5},
+                        {"monster_alien_slave", 7},
+                    }
+                },
+                { "c3a2b", new Dictionary<string, int>
+                    {
+                        {"monster_alien_slave", 4},
+                    }
+                },
+                { "c3a2c", new Dictionary<string, int>
+                    {
+                        {"monster_alien_grunt", 5},
+                        {"monster_alien_slave", 2},
+                        {"monster_headcrab", 5},
+                    }
+                },
+                { "c3a2d", new Dictionary<string, int>
+                    {
+                        {"monster_headcrab", 3},
+                        {"monster_alien_controller", 3},
+                    }
+                },
+                { "c4a1", new Dictionary<string, int>
+                    {
+                        {"monster_alien_slave", 2},
+                        {"monster_houndeye", 5},
+                        {"func_breakable", 4},
+                    }
+                },
+                { "c4a2", new Dictionary<string, int>
+                    {
+                        {"monster_headcrab", 2},
+                    }
+                },
+                { "c4a2a", new Dictionary<string, int>
+                    {
+                        {"monster_headcrab", 3},
+                    }
+                },
+                { "c4a2b", new Dictionary<string, int>
+                    {
+                        {"monster_bigmomma", 1},
+                    }
+                },
+                { "c4a1a", new Dictionary<string, int>
+                    {
+                        {"monster_alien_slave", 6},
+                        {"monster_alien_controller", 5},
+                        {"monster_headcrab", 2},
+                        {"monster_barnacle", 3},
+                        {"monster_bullchicken", 1},
+                    }
+                },
+                { "c4a1b", new Dictionary<string, int>
+                    {
+                        {"monster_alien_grunt", 6},
+                        {"monster_alien_slave", 5},
+                        {"monster_alien_controller", 3},
+                        {"monster_gargantua", 1},
+                        {"monster_barnacle", 3},
+                    }
+                },
+                { "c4a1c", new Dictionary<string, int>
+                    {
+                        {"monster_alien_slave", 6},
+                        {"monster_alien_controller", 2},
+                    }
+                },
+                { "c4a1d", new Dictionary<string, int>
+                    {
+                        {"monster_alien_slave", 18},
+                        {"monster_alien_controller", 9},
+                        {"monster_alien_grunt", 12},
+                    }
+                },
+                { "c4a1e", new Dictionary<string, int>
+                    {
+                        {"monster_alien_slave", 13},
+                        {"monster_alien_controller", 9},
+                        {"monster_alien_grunt", 8},
+                    }
+                },
+                { "c4a3", new Dictionary<string, int>
+                    {
+                        {"monster_alien_controller", 8},
+                        {"monster_alien_slave", 3},
+                        {"monster_ichthyosaur", 1},
+                        {"monster_gargantua", 1},
+                        {"monster_nihilanth", 1},
+                    }
+                },
+            };
+
+            Dictionary<string, Dictionary<string, int>> monsterCountsByMap = new Dictionary<string, Dictionary<string, int>>();
+
+            foreach (var map in MonsterTypeKillByMap)
+            {
+                foreach (var kill in MonsterTypeKillByMap[map.Key])
+                {
+                    if (!monsterCountsByMap.ContainsKey(map.Key))
+                    {
+                        monsterCountsByMap.Add(map.Key, new Dictionary<string, int>());
+                    }
+                    if (!monsterCountsByMap[map.Key].ContainsKey(kill.Item2))
+                    {
+                        monsterCountsByMap[map.Key].Add(kill.Item2, 0);
+                    }
+                    monsterCountsByMap[map.Key][kill.Item2]++;
+                }
+            }
+
+            foreach (var map in referenceMonsterCountsByMap)
+            {
+                foreach (var monsterTypeKills in referenceMonsterCountsByMap[map.Key])
+                {
+                    if (!monsterCountsByMap.ContainsKey(map.Key) || !monsterCountsByMap[map.Key].ContainsKey(monsterTypeKills.Key))
+                    {
+                        textBuffer.Append(
+                            "HL100: Expected " +
+                            referenceMonsterCountsByMap[map.Key][monsterTypeKills.Key] + " " +
+                            monsterTypeKills.Key + " kills on " +
+                            map.Key + ". Found no kills for this monster type on this map in demos.\n",
+                            Color.Yellow);
+                        hasWarnings = true;
+                    }
+
+                    else if (monsterCountsByMap[map.Key][monsterTypeKills.Key] != referenceMonsterCountsByMap[map.Key][monsterTypeKills.Key])
+                    {
+                        textBuffer.Append(
+                            "HL100: Expected " +
+                            referenceMonsterCountsByMap[map.Key][monsterTypeKills.Key] + " " +
+                            monsterTypeKills.Key + " kills on " +
+                            map.Key + ". Got " +
+                            monsterCountsByMap[map.Key][monsterTypeKills.Key] + " kills.\n",
+                            Color.Yellow);
+                        hasWarnings = true;
+                    }
+                }
+            }
+
+            if (hasErrors)
+            {
+                textBuffer.Append("\nHL100: Verification did not pass.\n", Color.Red);
+            }
+            else if (hasWarnings)
+            {
+                textBuffer.Append("\nHL100: Verification passed with warnings. Note that report_to_demo commands can sometimes get missed.\n", Color.Yellow);
+            }
+            else
+            {
+                textBuffer.Append("\nHL100: Verification passed.\n", Color.Green);
             }
         }
 
@@ -170,7 +803,6 @@ namespace VolvoWrench.Demo_Stuff.GoldSource
             Df.Clear();
             MonsterTypeKillByNumber.Clear();
             MonsterTypeKillByMap.Clear();
-            MonsterNameKillByMap.Clear();
             mrtb.Text = $@"Please wait. Parsing demos... 0/{files.Length}";
             var curr = 0;
             foreach (var dt in files.Where(file => File.Exists(file) && Path.GetExtension(file) == ".dem"))
@@ -1220,18 +1852,6 @@ Human readable time:        {TimeSpan.FromSeconds(Df.Sum(x => x.Value.GsDemoInfo
                                                     }
                                                 }
                                             }
-
-                                            foreach (var map in MonsterNameKillByMap)
-                                            {
-                                                for (int j = 0; j < MonsterNameKillByMap[map.Key].Count(); j++)
-                                                {
-                                                    if (MonsterNameKillByMap[map.Key][j].Item1 == oldUUID)
-                                                    {
-                                                        MonsterNameKillByMap[map.Key].RemoveAt(j);
-                                                        j--;
-                                                    }
-                                                }
-                                            }
                                         }
 
                                         string killUUID = Guid.NewGuid().ToString();
@@ -1240,12 +1860,7 @@ Human readable time:        {TimeSpan.FromSeconds(Df.Sum(x => x.Value.GsDemoInfo
                                         {
                                             MonsterTypeKillByMap.Add(monsterKilledOnMap, new List<(string, string, string)>());
                                         }
-                                        if (!MonsterNameKillByMap.ContainsKey(monsterKilledOnMap))
-                                        {
-                                            MonsterNameKillByMap.Add(monsterKilledOnMap, new List<(string, string, string)>());
-                                        }
-                                        MonsterTypeKillByMap[monsterKilledOnMap].Append((killUUID, monsterType, info.Key));
-                                        MonsterNameKillByMap[monsterKilledOnMap].Append((killUUID, monsterName, info.Key));
+                                        MonsterTypeKillByMap[monsterKilledOnMap].Add((killUUID, monsterType, info.Key));
                                     } catch (Exception e)
                                     {
                                         textBuffer.Append("\tError parsing hl100 report_to_demo in " + info.Key + ": " + e.ToString() + "\n");

--- a/VolvoWrench/Demo stuff/GoldSource/Verification.cs
+++ b/VolvoWrench/Demo stuff/GoldSource/Verification.cs
@@ -761,8 +761,10 @@ namespace VolvoWrench.Demo_Stuff.GoldSource
             {
                 if (!MonsterTypeKillByNumber.ContainsKey(i))
                 {
-                    textBuffer.Append("HL100: Missing kill #" + i + "\n", WarningColor);
-                    hasWarnings = true;
+                    string err = "HL100: Missing kill #" + i + "\n";
+                    Df[files.Last()].GsDemoInfo.ParsingErrors.Add(err);
+                    textBuffer.Append(err, IllegalColor);
+                    hasErrors = true;
                 }
             }
 
@@ -825,8 +827,7 @@ namespace VolvoWrench.Demo_Stuff.GoldSource
             else if (hasWarnings)
             {
                 textBuffer.Append("\nHL100: Verification passed with warnings. " +
-                    "Note that report_to_demo commands can sometimes get missed, " +
-                    "or kills may happen on the other side of level transitions.\n",
+                    "Note that kills may happen on unexpected maps due to crossing level transitions.\n",
                     WarningColor);
             }
             else

--- a/VolvoWrench/Demo stuff/GoldSource/Verification.cs
+++ b/VolvoWrench/Demo stuff/GoldSource/Verification.cs
@@ -141,39 +141,6 @@ namespace VolvoWrench.Demo_Stuff.GoldSource
             bool hasWarnings = false;
             const int totalKills = 944;
 
-            // Verify they got exactly totalKills kills
-            for (int i = 1; i <= totalKills; i++)
-            {
-                if (!MonsterTypeKillByNumber.ContainsKey(i))
-                {
-                    textBuffer.Append("HL100: Missing kill #" + i + "\n", Color.Yellow);
-                    hasWarnings = true;
-                }
-            }
-
-            if (MonsterTypeKillByNumber.Count() > totalKills)
-            {
-                // Add error to last demo for extra kills
-                string err = "HL100: Extra kills in run! There should only be " + totalKills + ".\n";
-                Df[files.Last()].GsDemoInfo.ParsingErrors.Add(err);
-                textBuffer.Append(err, Color.Red);
-                hasErrors = true;
-            }
-
-            // Verify the last kill is Nihilanth
-            if (!MonsterTypeKillByNumber.ContainsKey(totalKills) || MonsterTypeKillByNumber[totalKills].Item2 != "monster_nihilanth")
-            {
-                // Add error to last demo for missing kill
-                string err = "HL100: Last kill is not nihilanth or there is no " + totalKills + "th kill!\n";
-                Df[files.Last()].GsDemoInfo.ParsingErrors.Add(err);
-                textBuffer.Append(err, Color.Red);
-                hasErrors = true;
-            }
-            else
-            {
-                textBuffer.Append("\nHL100: Got 944 kills with Nihilanth as the final kill.\n\n", Color.Green);
-            }
-
             Dictionary<string, Dictionary<string, int>> referenceMonsterCountsByMap = new Dictionary<string, Dictionary<string, int>>
             {
                 { "c1a1", new Dictionary<string, int>
@@ -734,6 +701,7 @@ namespace VolvoWrench.Demo_Stuff.GoldSource
 
             Dictionary<string, Dictionary<string, int>> monsterCountsByMap = new Dictionary<string, Dictionary<string, int>>();
 
+            // Build dict of kills of by map and monster type
             foreach (var map in MonsterTypeKillByMap)
             {
                 foreach (var kill in MonsterTypeKillByMap[map.Key])
@@ -748,6 +716,50 @@ namespace VolvoWrench.Demo_Stuff.GoldSource
                     }
                     monsterCountsByMap[map.Key][kill.Item2]++;
                 }
+            }
+
+            // Dump the kills by map to the textBuffer so it can be cross referenced with the spreadsheet if needed.
+            foreach (var map in monsterCountsByMap)
+            {
+                textBuffer.Append("\nHL100: Kills on " + map.Key + "\n");
+                foreach (var kill in monsterCountsByMap[map.Key])
+                {
+                    textBuffer.Append("  " + kill.Key + ": " + kill.Value + "\n");
+                }
+            }
+            textBuffer.Append("\n");
+
+            // Verify they got exactly totalKills kills
+            for (int i = 1; i <= totalKills; i++)
+            {
+                if (!MonsterTypeKillByNumber.ContainsKey(i))
+                {
+                    textBuffer.Append("HL100: Missing kill #" + i + "\n", Color.Yellow);
+                    hasWarnings = true;
+                }
+            }
+
+            if (MonsterTypeKillByNumber.Count() > totalKills)
+            {
+                // Add error to last demo for extra kills
+                string err = "HL100: Extra kills in run! There should only be " + totalKills + ".\n";
+                Df[files.Last()].GsDemoInfo.ParsingErrors.Add(err);
+                textBuffer.Append(err, Color.Red);
+                hasErrors = true;
+            }
+
+            // Verify the last kill is Nihilanth
+            if (!MonsterTypeKillByNumber.ContainsKey(totalKills) || MonsterTypeKillByNumber[totalKills].Item2 != "monster_nihilanth")
+            {
+                // Add error to last demo for missing kill
+                string err = "HL100: Last kill is not nihilanth or there is no " + totalKills + "th kill!\n";
+                Df[files.Last()].GsDemoInfo.ParsingErrors.Add(err);
+                textBuffer.Append(err, Color.Red);
+                hasErrors = true;
+            }
+            else
+            {
+                textBuffer.Append("\nHL100: Got 944 kills with Nihilanth as the final kill.\n\n", Color.Green);
             }
 
             foreach (var map in referenceMonsterCountsByMap)

--- a/VolvoWrench/Demo stuff/GoldSource/Verification.cs
+++ b/VolvoWrench/Demo stuff/GoldSource/Verification.cs
@@ -1,12 +1,11 @@
-﻿using System;
+﻿using MoreLinq;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 using System.Windows.Forms;
-using MoreLinq;
 using VolvoWrench.Demo_stuff.GoldSource;
 
 namespace VolvoWrench.Demo_Stuff.GoldSource
@@ -41,7 +40,7 @@ namespace VolvoWrench.Demo_Stuff.GoldSource
         ///     Dictionaries related to HL100 kill counting
         /// </summary>
         // Kill Number : UUID, Monster Type, Monster Name, Map
-        private Dictionary<int, (string, string, string, string)> MonsterTypeKillByNumber = new Dictionary<int, (string, string, string, string)>();
+        private SortedDictionary<int, (string, string, string, string)> MonsterTypeKillByNumber = new SortedDictionary<int, (string, string, string, string)>();
         // Map : [ UUID, Monster Type ]
         private Dictionary<string, List<(string, string)>> MonsterTypeKillByMap = new Dictionary<string, List<(string, string)>>();
 
@@ -106,6 +105,69 @@ namespace VolvoWrench.Demo_Stuff.GoldSource
                 ni.Visible = true;
                 ni.ShowBalloonTip(5000, "VolvoWrench", "Demo names copied to clipboard", ToolTipIcon.Info);
             }
+        }
+
+        /// <summary>
+        ///     Get chapter short name from level name. HL1 only at the moment.
+        /// </summary>
+        /// <param name="map">Level to find chapter for</param>
+        string MapToChapter(string map)
+        {
+            if (map.StartsWith("c0"))
+                return "AM";
+
+            else if (map == "c1a0" || map == "c1a0d" || map == "c1a0a" || map == "c1a0b" || map == "c1a0c" || map == "c1a0e" ||
+                     map == "c1a1" || map == "c1a1a" || map == "c1a1f" || map == "c1a1b" || map == "c1a1c" || map == "c1a1d")
+                return "UC";
+
+            else if (map == "c1a2" || map == "c1a2a" || map == "c1a2b" || map == "c1a2c" || map == "c1a2d")
+                return "OC";
+
+            else if (map == "c1a3" || map == "c1a3a" || map == "c1a3b" || map == "c1a3c" || map == "c1a3d")
+                return "WGH";
+
+            else if (map == "c1a4" || map == "c1a4k" || map == "c1a4b" || map == "c1a4f" || map == "c1a4d" ||
+                     map == "c1a4e" || map == "c1a4i" || map == "c1a4g" || map == "c1a4j")
+                return "BP";
+
+            else if (map == "c2a1" || map == "c2a1a" || map == "c2a1b")
+                return "PU";
+
+            else if (map == "c2a2" || map == "c2a2a" || map == "c2a2b1" || map == "c2a2b2" || map == "c2a2c" ||
+                     map == "c2a2d" || map == "c2a2e" || map == "c2a2f" || map == "c2a2g" || map == "c2a2h")
+                return "OAR";
+
+            else if (map == "c2a3" || map == "c2a3a" || map == "c2a3b" || map == "c2a3c" || map == "c2a3d" || map == "c2a3e")
+                return "APP";
+
+            else if (map == "c2a4" || map == "c2a4a" || map == "c2a4b" || map == "c2a4c")
+                return "RP";
+
+            else if (map == "c2a4d" || map == "c2a4e" || map == "c2a4f" || map == "c2a4g")
+                return "QE";
+
+            else if (map == "c2a5" || map == "c2a5w" || map == "c2a5x" || map == "c2a5a" || map == "c2a5b" ||
+                     map == "c2a5c" || map == "c2a5d" || map == "c2a5e" || map == "c2a5f" || map == "c2a5g")
+                return "ST";
+
+            else if (map == "c3a1" || map == "c3a1a" || map == "c3a1b")
+                return "FAF";
+
+            else if (map == "c3a2e" || map == "c3a2" || map == "c3a2a" || map == "c3a2b" || map == "c3a2c" ||
+                     map == "c3a2d" || map == "c3a2f")
+                return "LC";
+
+            else if (map == "c4a1")
+                return "XEN";
+
+            else if (map == "c4a1" || map == "c4a2" || map == "c4a2a" || map == "c4a2b")
+                return "GL";
+
+            else if (map == "c4a1a" || map == "c4a1b" || map == "c4a1c" || map == "c4a1d" || map == "c4a1e" || map == "c4a1f")
+                return "INT";
+
+            else
+                return "END";
         }
 
         /// <summary>
@@ -701,6 +763,174 @@ namespace VolvoWrench.Demo_Stuff.GoldSource
                 },
             };
 
+            Dictionary<string, Dictionary<string, int>> referenceMonsterCountsByChapter = new Dictionary<string, Dictionary<string, int>>
+            {
+                { "UC", new Dictionary<string, int>
+                    {
+                        {"monster_alien_slave", 1},
+                        {"monster_barnacle", 7},
+                        {"monster_bullchicken", 2},
+                        {"monster_headcrab", 24},
+                        {"monster_houndeye", 5},
+                        {"monster_zombie", 9},
+                    }
+                },
+                { "OC", new Dictionary<string, int>
+                    {
+                        {"monster_alien_slave", 14},
+                        {"monster_barnacle", 9},
+                        {"monster_bullchicken", 3},
+                        {"monster_headcrab", 53},
+                        {"monster_miniturret", 2},
+                        {"monster_zombie", 9},
+                    }
+                },
+                { "WGH", new Dictionary<string, int>
+                    {
+                        {"monster_alien_slave", 2},
+                        {"monster_barnacle", 11},
+                        {"monster_headcrab", 4},
+                        {"monster_human_grunt", 19},
+                        {"monster_osprey", 2},
+                        {"monster_sentry", 10},
+                        {"monster_zombie", 1},
+                    }
+                },
+                { "BP", new Dictionary<string, int>
+                    {
+                        {"monster_barnacle", 5},
+                        {"monster_bullchicken", 15},
+                        {"monster_headcrab", 14},
+                        {"monster_houndeye", 14},
+                        {"monster_tentacle", 3},
+                        {"monster_zombie", 13},
+                    }
+                },
+                { "PU", new Dictionary<string, int>
+                    {
+                        {"monster_alien_slave", 9},
+                        {"monster_bullchicken", 1},
+                        {"monster_gargantua", 1},
+                        {"monster_headcrab", 12},
+                        {"monster_houndeye", 5},
+                        {"monster_human_grunt", 19},
+                        {"monster_sentry", 1},
+                        {"monster_zombie", 1},
+                    }
+                },
+                { "OAR", new Dictionary<string, int>
+                    {
+                        {"func_breakable", 1},
+                        {"monster_alien_slave", 22},
+                        {"monster_barnacle", 12},
+                        {"monster_bullchicken", 10},
+                        {"monster_headcrab", 20},
+                        {"monster_houndeye", 8},
+                        {"monster_human_grunt", 47},
+                        {"monster_sentry", 10},
+                        {"monster_zombie", 2},
+                    }
+                },
+                { "APP", new Dictionary<string, int>
+                    {
+                        {"monster_alien_slave", 13},
+                        {"monster_barnacle", 13},
+                        {"monster_bullchicken", 3},
+                        {"monster_headcrab", 7},
+                        {"monster_human_assassin", 3},
+                        {"monster_ichthyosaur", 3},
+                        {"monster_zombie", 2},
+                    }
+                },
+                { "RP", new Dictionary<string, int>
+                    {
+                        {"monster_barnacle", 10},
+                        {"monster_bullchicken", 5},
+                        {"monster_headcrab", 10},
+                    }
+                },
+                { "QE", new Dictionary<string, int>
+                    {
+                        {"monster_alien_grunt", 3},
+                        {"monster_headcrab", 19},
+                        {"monster_houndeye", 9},
+                        {"monster_human_grunt", 17},
+                        {"monster_sentry", 2},
+                    }
+                },
+                { "ST", new Dictionary<string, int>
+                    {
+                        {"func_breakable", 7},
+                        {"monster_alien_grunt", 19},
+                        {"monster_alien_slave", 13},
+                        {"monster_apache", 3},
+                        {"monster_gargantua", 1},
+                        {"monster_headcrab", 18},
+                        {"monster_houndeye", 1},
+                        {"monster_human_grunt", 58},
+                        {"monster_ichthyosaur", 1},
+                        {"monster_osprey", 1},
+                        {"monster_sentry", 2},
+                    }
+                },
+                { "FAF", new Dictionary<string, int>
+                    {
+                        {"func_breakable", 2},
+                        {"monster_alien_grunt", 14},
+                        {"monster_alien_slave", 8},
+                        {"monster_barnacle", 5},
+                        {"monster_headcrab", 5},
+                        {"monster_human_grunt", 8},
+                        {"monster_ichthyosaur", 1},
+                        {"monster_sentry", 3},
+                        {"monster_turret", 1},
+                    }
+                },
+                { "LC", new Dictionary<string, int>
+                    {
+                        {"monster_alien_controller", 3},
+                        {"monster_alien_grunt", 20},
+                        {"monster_alien_slave", 13},
+                        {"monster_barnacle", 6},
+                        {"monster_bullchicken", 2},
+                        {"monster_headcrab", 25},
+                    }
+                },
+                { "XEN", new Dictionary<string, int>
+                    {
+                        {"func_breakable", 4},
+                        {"monster_alien_slave", 2},
+                        {"monster_houndeye", 5},
+                    }
+                },
+                { "GL", new Dictionary<string, int>
+                    {
+                        {"monster_bigmomma", 1},
+                        {"monster_headcrab", 5},
+                    }
+                },
+                { "INT", new Dictionary<string, int>
+                    {
+                        {"monster_alien_controller", 28},
+                        {"monster_alien_grunt", 26},
+                        {"monster_alien_slave", 48},
+                        {"monster_barnacle", 6},
+                        {"monster_bullchicken", 1},
+                        {"monster_gargantua", 1},
+                        {"monster_headcrab", 2},
+                    }
+                },
+                { "END", new Dictionary<string, int>
+                    {
+                        {"monster_alien_controller", 8},
+                        {"monster_alien_slave", 3},
+                        {"monster_gargantua", 1},
+                        {"monster_ichthyosaur", 1},
+                        {"monster_nihilanth", 1},
+                    }
+                },
+            };
+
             Dictionary<string, Dictionary<string, int>> monsterCountsByMap = new Dictionary<string, Dictionary<string, int>>();
 
             // Build dict of kills of by map and monster type
@@ -720,39 +950,127 @@ namespace VolvoWrench.Demo_Stuff.GoldSource
                 }
             }
 
-            // Dump the kills by map to the textBuffer so it can be cross referenced with the spreadsheet if needed.
-            foreach (var map in monsterCountsByMap)
+            List<(string, Color)> killsByCountLines = new List<(string, Color)>();
+            List<(string, Color)> killsByMapLines = new List<(string, Color)>();
+            List<(string, Color)> killsByChapterLines = new List<(string, Color)>();
+
+            textBuffer.Append("HL100 Kill table:\n");
+            // Dump the kills by map to the output so it can be cross referenced with the spreadsheet if needed.
+            foreach (var map in referenceMonsterCountsByMap)
             {
-                textBuffer.Append("\nHL100: Kills on " + map.Key + "\n");
-                foreach (var kill in monsterCountsByMap[map.Key])
+                killsByMapLines.Add(($"Kills on {map.Key}:", Color.White));
+                foreach (var kill in referenceMonsterCountsByMap[map.Key])
                 {
-                    textBuffer.Append("  " + kill.Key + ": " + kill.Value + "\n");
+                    int actualKills = 0;
+                    if (monsterCountsByMap.ContainsKey(map.Key) && monsterCountsByMap[map.Key].ContainsKey(kill.Key))
+                    {
+                        actualKills = monsterCountsByMap[map.Key][kill.Key];
+                    }
+                    Color c = Color.White;
+                    if (actualKills != kill.Value)
+                    {
+                        c = WarningColor;
+                    }
+                    killsByMapLines.Add(($"  {kill.Key}: {actualKills} (Expected: {kill.Value})", c));
+                }
+                killsByMapLines.Add(("", Color.White));
+            }
+
+            var monsterCountsByChapter = new Dictionary<string, Dictionary<string, int>>();
+
+            foreach (var kv in monsterCountsByMap)
+            {
+                var mapName = kv.Key;
+                var monsters = kv.Value;
+                var chapter = MapToChapter(mapName);
+
+                if (!monsterCountsByChapter.TryGetValue(chapter, out var chapterDict))
+                {
+                    chapterDict = new Dictionary<string, int>();
+                    monsterCountsByChapter[chapter] = chapterDict;
+                }
+
+                foreach (var m in monsters)
+                {
+                    if (chapterDict.ContainsKey(m.Key))
+                        chapterDict[m.Key] += m.Value;
+                    else
+                        chapterDict[m.Key] = m.Value;
                 }
             }
-            textBuffer.Append("\n");
+
+            // Dump monsters by chapter to the textBuffer
+            foreach (var chapter in referenceMonsterCountsByChapter)
+            {
+                killsByChapterLines.Add(($"Kills on {chapter.Key}:", Color.White));
+                foreach (var m in chapter.Value)
+                {
+                    int actualKills = 0;
+                    if (monsterCountsByChapter.ContainsKey(chapter.Key) && monsterCountsByChapter[chapter.Key].ContainsKey(m.Key))
+                    {
+                        actualKills = monsterCountsByChapter[chapter.Key][m.Key];
+                    }
+                    Color c = Color.White;
+                    if (actualKills != m.Value)
+                    {
+                        c = WarningColor;
+                    }
+                    killsByChapterLines.Add(($"  {m.Key}: {actualKills} (Expected: {m.Value})", c));
+                }
+                killsByChapterLines.Add(("", Color.White));
+                killsByChapterLines.Add(("", Color.White));
+            }
 
             // Dump the kills by number to the textBuffer so it can be cross referenced with the spreadsheet if needed.
-            textBuffer.Append("\nHL100: Kills by number:\n");
+            killsByCountLines.Add(("Kills by number:", Color.White));
             foreach (var kill in MonsterTypeKillByNumber)
             {
                 if (!string.IsNullOrEmpty(kill.Value.Item3))
                 {
-                    textBuffer.Append("  " + kill.Key);
-                    textBuffer.Append(": ", UnhighlightColor);
-                    textBuffer.Append(kill.Value.Item2);
-                    textBuffer.Append("'", UnhighlightColor);
-                    textBuffer.Append(kill.Value.Item3, NameColor);
-                    textBuffer.Append("' killed on ", UnhighlightColor);
-                    textBuffer.Append(kill.Value.Item4 + "\n");
+                    killsByCountLines.Add(($"  {kill.Key}: {kill.Value.Item2} '{kill.Value.Item3}' killed on {kill.Value.Item4}", Color.White));
                 }
                 else
                 {
-                    textBuffer.Append("  " + kill.Key);
-                    textBuffer.Append(": ", UnhighlightColor);
-                    textBuffer.Append(kill.Value.Item2);
-                    textBuffer.Append(" killed on ", UnhighlightColor);
-                    textBuffer.Append(kill.Value.Item4 + "\n");
+                    killsByCountLines.Add(($"  {kill.Key}: {kill.Value.Item2} killed on {kill.Value.Item4}", Color.White));
                 }
+            }
+
+            // Format as a more easily-readable table
+            for (int i = 0; i < Math.Max(killsByChapterLines.Count(), Math.Max(killsByMapLines.Count(), killsByCountLines.Count())); i++)
+            {
+                
+                if (i < killsByCountLines.Count())
+                {
+                    textBuffer.Append(killsByCountLines[i].Item1.PadRight(70), killsByCountLines[i].Item2);
+                }
+                else
+                {
+                    textBuffer.Append("".PadRight(70));
+                }
+
+                textBuffer.Append(" | ");
+
+                if (i < killsByMapLines.Count())
+                {
+                    textBuffer.Append(killsByMapLines[i].Item1.PadRight(50), killsByMapLines[i].Item2);
+                }
+                else
+                {
+                    textBuffer.Append("".PadRight(50));
+                }
+
+                textBuffer.Append(" | ");
+
+                if (i < killsByChapterLines.Count())
+                {
+                    textBuffer.Append(killsByChapterLines[i].Item1.PadRight(50), killsByChapterLines[i].Item2);
+                }
+                else
+                {
+                    textBuffer.Append("".PadRight(50));
+                }
+
+                textBuffer.Append("\n");
             }
             textBuffer.Append("\n");
 
@@ -768,6 +1086,19 @@ namespace VolvoWrench.Demo_Stuff.GoldSource
                 }
             }
 
+            // Verify there weren't any illegally bound report_to_demo commands
+            foreach (var df in Df)
+            {
+                foreach (var cheat in df.Value.GsDemoInfo.Cheats)
+                {
+                    if (cheat.ToUpper().Contains("REPORT_TO_DEMO"))
+                    {
+                        hasErrors = true;
+                    }
+                }
+            }
+
+            // Check for extra kills
             if (MonsterTypeKillByNumber.Count() > totalKills)
             {
                 // Add error to last demo for extra kills
@@ -846,6 +1177,8 @@ namespace VolvoWrench.Demo_Stuff.GoldSource
             Df.Clear();
             MonsterTypeKillByNumber.Clear();
             MonsterTypeKillByMap.Clear();
+            mrtb.Font = new Font("Consolas", 12, FontStyle.Regular); // Need a monospaced font for table output
+            mrtb.WordWrap = false;
             mrtb.Text = $@"Please wait. Parsing demos... 0/{files.Length}";
             var curr = 0;
             foreach (var dt in files.Where(file => File.Exists(file) && Path.GetExtension(file) == ".dem"))
@@ -1730,6 +2063,12 @@ Human readable time:        {TimeSpan.FromSeconds(Df.Sum(x => x.Value.GsDemoInfo
                                 if (command.ToUpper().Contains(";"))
                                 {
                                     textBuffer.Append("\t" + "Possible script: " + command + " — Frame: " + i + "\n");
+                                }
+                                if (command.ToUpper().Contains("REPORT_TO_DEMO"))
+                                {
+                                    textBuffer.Append("HL100: Illegal bound report_to_demo command!\n", IllegalColor);
+                                    info.Value.GsDemoInfo.Cheats.Add(command);
+
                                 }
                                 datanode.Nodes.Add(new TreeNode("Bound command: " + command)
                                 {

--- a/VolvoWrench/Demo stuff/GoldSource/Verification.cs
+++ b/VolvoWrench/Demo stuff/GoldSource/Verification.cs
@@ -28,6 +28,7 @@ namespace VolvoWrench.Demo_Stuff.GoldSource
         /// </summary>
         public static readonly Color IllegalColor = Color.LightCoral;
         public static readonly Color WarningColor = Color.Yellow;
+        public static readonly Color GoodColor = Color.Green;
 
         /// <summary>
         ///     Buffer holds strings to be printed
@@ -734,7 +735,7 @@ namespace VolvoWrench.Demo_Stuff.GoldSource
             {
                 if (!MonsterTypeKillByNumber.ContainsKey(i))
                 {
-                    textBuffer.Append("HL100: Missing kill #" + i + "\n", Color.Yellow);
+                    textBuffer.Append("HL100: Missing kill #" + i + "\n", WarningColor);
                     hasWarnings = true;
                 }
             }
@@ -744,7 +745,7 @@ namespace VolvoWrench.Demo_Stuff.GoldSource
                 // Add error to last demo for extra kills
                 string err = "HL100: Extra kills in run! There should only be " + totalKills + ".\n";
                 Df[files.Last()].GsDemoInfo.ParsingErrors.Add(err);
-                textBuffer.Append(err, Color.Red);
+                textBuffer.Append(err, IllegalColor);
                 hasErrors = true;
             }
 
@@ -754,7 +755,7 @@ namespace VolvoWrench.Demo_Stuff.GoldSource
                 // Add error to last demo for missing kill
                 string err = "HL100: Last kill is not nihilanth or there is no " + totalKills + "th kill!\n";
                 Df[files.Last()].GsDemoInfo.ParsingErrors.Add(err);
-                textBuffer.Append(err, Color.Red);
+                textBuffer.Append(err, IllegalColor);
                 hasErrors = true;
             }
             else
@@ -773,7 +774,7 @@ namespace VolvoWrench.Demo_Stuff.GoldSource
                             referenceMonsterCountsByMap[map.Key][monsterTypeKills.Key] + " " +
                             monsterTypeKills.Key + " kills on " +
                             map.Key + ". Found no kills for this monster type on this map in demos.\n",
-                            Color.Yellow);
+                            WarningColor);
                         hasWarnings = true;
                     }
 
@@ -785,7 +786,7 @@ namespace VolvoWrench.Demo_Stuff.GoldSource
                             monsterTypeKills.Key + " kills on " +
                             map.Key + ". Got " +
                             monsterCountsByMap[map.Key][monsterTypeKills.Key] + " kills.\n",
-                            Color.Yellow);
+                            WarningColor);
                         hasWarnings = true;
                     }
                 }
@@ -793,15 +794,15 @@ namespace VolvoWrench.Demo_Stuff.GoldSource
 
             if (hasErrors)
             {
-                textBuffer.Append("\nHL100: Verification did not pass.\n", Color.Red);
+                textBuffer.Append("\nHL100: Verification did not pass.\n", IllegalColor);
             }
             else if (hasWarnings)
             {
-                textBuffer.Append("\nHL100: Verification passed with warnings. Note that report_to_demo commands can sometimes get missed.\n", Color.Yellow);
+                textBuffer.Append("\nHL100: Verification passed with warnings. Note that report_to_demo commands can sometimes get missed.\n", WarningColor);
             }
             else
             {
-                textBuffer.Append("\nHL100: Verification passed.\n", Color.Green);
+                textBuffer.Append("\nHL100: Verification passed.\n", GoodColor);
             }
         }
 
@@ -1793,7 +1794,8 @@ Human readable time:        {TimeSpan.FromSeconds(Df.Sum(x => x.Value.GsDemoInfo
                                         textBuffer.Append("\t" + command + "\n", WarningColor);
                                     }
                                 }
-                                if (command.ToUpper().Contains("HOST_")
+                                if (!command.ToUpper().StartsWith("REPORT_TO_DEMO") &&
+                                   ( command.ToUpper().Contains("HOST_")
                                   || command.ToUpper().Contains("SK_")
                                   || command.ToUpper().Contains("CHASE")
                                   || command.ToUpper().Contains("SKILL")
@@ -1811,7 +1813,7 @@ Human readable time:        {TimeSpan.FromSeconds(Df.Sum(x => x.Value.GsDemoInfo
                                   || command.ToUpper().Contains("SCR_")
                                   || command.ToUpper().StartsWith("C_")
                                   || command.ToUpper().Contains("CAM")
-                                  || command.ToUpper().Contains("JOY"))
+                                  || command.ToUpper().Contains("JOY")))
                                 {
                                     textBuffer.Append("\t" + "Disallowed: " + command + " — Frame: " + i + "\n", IllegalColor);
                                 }

--- a/VolvoWrench/Demo stuff/GoldSource/Verification.cs
+++ b/VolvoWrench/Demo stuff/GoldSource/Verification.cs
@@ -35,6 +35,16 @@ namespace VolvoWrench.Demo_Stuff.GoldSource
         private ColoredTextBuffer textBuffer;
 
         /// <summary>
+        ///     Dictionaries related to HL100 kill counting
+        /// </summary>
+        // Kill Number, UUID, Monster Type
+        private Dictionary<int, (string, string, string)> MonsterTypeKillByNumber = new Dictionary<int, (string, string, string)>();
+        // Map, UUID, Monster Type
+        private Dictionary<string, List<(string, string, string)>> MonsterTypeKillByMap = new Dictionary<string, List<(string, string, string)>>();
+        // Map, UUID, Monster Name
+        private Dictionary<string, List<(string, string, string)>> MonsterNameKillByMap = new Dictionary<string, List<(string, string, string)>>();
+
+        /// <summary>
         ///     Default constructor
         /// </summary>
         public Verification()
@@ -98,12 +108,69 @@ namespace VolvoWrench.Demo_Stuff.GoldSource
         }
 
         /// <summary>
+        ///     Get the demo number from the name of the demo (i.e. demo_100.dem => 100)
+        /// </summary>
+        /// <param name="demoName">Filename of the demo</param>
+        private int demoNumberFromString(string demoName)
+        {
+            try
+            {
+                // Substring the number
+                int numberStart = demoName.LastIndexOf('_')+1;
+                int numberEnd = demoName.LastIndexOf(".");
+                string numStr = demoName.Substring(numberStart, numberEnd - numberStart);
+                return int.Parse(numStr);
+            } catch (Exception e)
+            {
+                MessageBox.Show(
+                    "Could not parse demo number from filename: " + demoName + "\n\n" + e.Message,
+                    "Error",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Error
+                );
+                return int.MinValue;
+            }
+        }
+
+        /// <summary>
+        ///     Verifies the kills in an HL100 run
+        /// </summary>
+        /// <param name="files">Demo files</param>
+        /// <param name="textBuffer">Verification output log</param>
+        public void VerifyHl100Kills(string[] files, ColoredTextBuffer textBuffer)
+        {
+            // Verify they got exactly 944 kills
+            for (int i = 1; i <= 944; i++)
+            {
+                if (!MonsterTypeKillByNumber.ContainsKey(i))
+                {
+                    // Add error to last demo for missing kill
+                    string err = "HL100: Missing kill #" + i + "\n";
+                    Df[files.Last()].GsDemoInfo.ParsingErrors.Add(err);
+                    textBuffer.Append(err, Color.Red);
+                }
+            }
+
+            // Verify the last kill is Nihilanth
+            if (!MonsterTypeKillByNumber.ContainsKey(944) || MonsterTypeKillByNumber[944].Item2 != "monster_nihilanth")
+            {
+                string err = "HL100: Last kill is not nihilanth!\n";
+                Df[files.Last()].GsDemoInfo.ParsingErrors.Add(err);
+                textBuffer.Append(err, Color.Red);
+            }
+        }
+
+        /// <summary>
         ///     This is the actuall verification method
         /// </summary>
         /// <param name="files">The paths of the files</param>
         public void Verify(string[] files)
         {
+            files = files.OrderBy(f => demoNumberFromString(f)).ToArray(); // HL100 needs the demos to be parsed in order
             Df.Clear();
+            MonsterTypeKillByNumber.Clear();
+            MonsterTypeKillByMap.Clear();
+            MonsterNameKillByMap.Clear();
             mrtb.Text = $@"Please wait. Parsing demos... 0/{files.Length}";
             var curr = 0;
             foreach (var dt in files.Where(file => File.Exists(file) && Path.GetExtension(file) == ".dem"))
@@ -162,6 +229,10 @@ Human readable time:        {TimeSpan.FromSeconds(Df.Sum(x => x.Value.GsDemoInfo
                     textBuffer.Append("\n");
                     mrtb.Text = $@"Please wait. Analyzing demos... {cur++}/{files.Length}";
                     Application.DoEvents();
+                }
+                if (MonsterTypeKillByNumber.Count > 0)
+                {
+                    VerifyHl100Kills(files, textBuffer);
                 }
                 mrtb.Clear();
                 textBuffer.AppendToRichTextBox(mrtb);
@@ -904,7 +975,7 @@ Human readable time:        {TimeSpan.FromSeconds(Df.Sum(x => x.Value.GsDemoInfo
             }
 
             string gamedir = info.Value.GsDemoInfo.Header.GameDir;
-            bool gameLooksLikeTrilogy = gamedir.StartsWith("valve") || gamedir.StartsWith("gearbox") || gamedir.StartsWith("bshift");
+            bool gameLooksLikeTrilogy = gamedir.StartsWith("valve") || gamedir.StartsWith("gearbox") || gamedir.StartsWith("bshift") || gamedir.StartsWith("killcount");
 
             if (gameLooksLikeTrilogy)
             {
@@ -1117,6 +1188,68 @@ Human readable time:        {TimeSpan.FromSeconds(Df.Sum(x => x.Value.GsDemoInfo
                                   || command.ToUpper().StartsWith("STAT"))
                                 {
                                     textBuffer.Append("\t" + "Probably disallowed ¯\\_(ツ)_/¯: " + command + " — Frame: " + i + "\n");
+                                }
+                                if (command.ToUpper().Contains("REPORT_TO_DEMO"))
+                                {
+                                    try
+                                    {
+                                        // Special HL100 command to report kills to demo
+                                        string[] tokens = command.Split();
+                                        string monsterType = tokens[1];
+                                        string monsterName = tokens[2].Substring(1, tokens[2].Length - 2); // may be empty
+                                        string monsterKilledOnMap = tokens[4];
+                                        int monsterKillNumber = int.Parse(tokens[6]);
+
+                                        // Check if this kill was already gotten (implies save-reload)
+                                        if (MonsterTypeKillByNumber.ContainsKey(monsterKillNumber))
+                                        {
+                                            // Get the UUID of the old kill that was invalidated by save-reload
+                                            string oldUUID = MonsterTypeKillByNumber[monsterKillNumber].Item1;
+
+                                            // Remove from dicts
+                                            MonsterTypeKillByNumber.Remove(monsterKillNumber);
+                                            
+                                            foreach (var map in MonsterTypeKillByMap)
+                                            {
+                                                for (int j = 0; j < MonsterTypeKillByMap[map.Key].Count(); j++)
+                                                {
+                                                    if (MonsterTypeKillByMap[map.Key][j].Item1 == oldUUID)
+                                                    {
+                                                        MonsterTypeKillByMap[map.Key].RemoveAt(j);
+                                                        j--;
+                                                    }
+                                                }
+                                            }
+
+                                            foreach (var map in MonsterNameKillByMap)
+                                            {
+                                                for (int j = 0; j < MonsterNameKillByMap[map.Key].Count(); j++)
+                                                {
+                                                    if (MonsterNameKillByMap[map.Key][j].Item1 == oldUUID)
+                                                    {
+                                                        MonsterNameKillByMap[map.Key].RemoveAt(j);
+                                                        j--;
+                                                    }
+                                                }
+                                            }
+                                        }
+
+                                        string killUUID = Guid.NewGuid().ToString();
+                                        MonsterTypeKillByNumber[monsterKillNumber] = (killUUID, monsterType, info.Key);
+                                        if (!MonsterTypeKillByMap.ContainsKey(monsterKilledOnMap))
+                                        {
+                                            MonsterTypeKillByMap.Add(monsterKilledOnMap, new List<(string, string, string)>());
+                                        }
+                                        if (!MonsterNameKillByMap.ContainsKey(monsterKilledOnMap))
+                                        {
+                                            MonsterNameKillByMap.Add(monsterKilledOnMap, new List<(string, string, string)>());
+                                        }
+                                        MonsterTypeKillByMap[monsterKilledOnMap].Append((killUUID, monsterType, info.Key));
+                                        MonsterNameKillByMap[monsterKilledOnMap].Append((killUUID, monsterName, info.Key));
+                                    } catch (Exception e)
+                                    {
+                                        textBuffer.Append("\tError parsing hl100 report_to_demo in " + info.Key + ": " + e.ToString() + "\n");
+                                    }
                                 }
                                 break;
                             }

--- a/VolvoWrench/Demo stuff/GoldSource/Verification.cs
+++ b/VolvoWrench/Demo stuff/GoldSource/Verification.cs
@@ -25,11 +25,10 @@ namespace VolvoWrench.Demo_Stuff.GoldSource
         /// <summary>
         ///     Static color definitions
         /// </summary>
+        public static readonly Color DefaultColor = Color.White;
         public static readonly Color IllegalColor = Color.LightCoral;
         public static readonly Color WarningColor = Color.Yellow;
         public static readonly Color GoodColor = Color.Green;
-        public static readonly Color UnhighlightColor = Color.LightGray;
-        public static readonly Color NameColor = Color.LightSteelBlue;
 
         /// <summary>
         ///     Buffer holds strings to be printed
@@ -958,7 +957,7 @@ namespace VolvoWrench.Demo_Stuff.GoldSource
             // Dump the kills by map to the output so it can be cross referenced with the spreadsheet if needed.
             foreach (var map in referenceMonsterCountsByMap)
             {
-                killsByMapLines.Add(($"Kills on {map.Key}:", Color.White));
+                killsByMapLines.Add(($"Kills on {map.Key}:", DefaultColor));
                 foreach (var kill in referenceMonsterCountsByMap[map.Key])
                 {
                     int actualKills = 0;
@@ -966,14 +965,14 @@ namespace VolvoWrench.Demo_Stuff.GoldSource
                     {
                         actualKills = monsterCountsByMap[map.Key][kill.Key];
                     }
-                    Color c = Color.White;
+                    Color c = DefaultColor;
                     if (actualKills != kill.Value)
                     {
                         c = WarningColor;
                     }
                     killsByMapLines.Add(($"  {kill.Key}: {actualKills} (Expected: {kill.Value})", c));
                 }
-                killsByMapLines.Add(("", Color.White));
+                killsByMapLines.Add(("", DefaultColor));
             }
 
             var monsterCountsByChapter = new Dictionary<string, Dictionary<string, int>>();
@@ -1002,7 +1001,7 @@ namespace VolvoWrench.Demo_Stuff.GoldSource
             // Dump monsters by chapter to the textBuffer
             foreach (var chapter in referenceMonsterCountsByChapter)
             {
-                killsByChapterLines.Add(($"Kills on {chapter.Key}:", Color.White));
+                killsByChapterLines.Add(($"Kills on {chapter.Key}:", DefaultColor));
                 foreach (var m in chapter.Value)
                 {
                     int actualKills = 0;
@@ -1010,28 +1009,28 @@ namespace VolvoWrench.Demo_Stuff.GoldSource
                     {
                         actualKills = monsterCountsByChapter[chapter.Key][m.Key];
                     }
-                    Color c = Color.White;
+                    Color c = DefaultColor;
                     if (actualKills != m.Value)
                     {
                         c = WarningColor;
                     }
                     killsByChapterLines.Add(($"  {m.Key}: {actualKills} (Expected: {m.Value})", c));
                 }
-                killsByChapterLines.Add(("", Color.White));
-                killsByChapterLines.Add(("", Color.White));
+                killsByChapterLines.Add(("", DefaultColor));
+                killsByChapterLines.Add(("", DefaultColor));
             }
 
             // Dump the kills by number to the textBuffer so it can be cross referenced with the spreadsheet if needed.
-            killsByCountLines.Add(("Kills by number:", Color.White));
+            killsByCountLines.Add(("Kills by number:", DefaultColor));
             foreach (var kill in MonsterTypeKillByNumber)
             {
                 if (!string.IsNullOrEmpty(kill.Value.Item3))
                 {
-                    killsByCountLines.Add(($"  {kill.Key}: {kill.Value.Item2} '{kill.Value.Item3}' killed on {kill.Value.Item4}", Color.White));
+                    killsByCountLines.Add(($"  {kill.Key}: {kill.Value.Item2} '{kill.Value.Item3}' killed on {kill.Value.Item4}", DefaultColor));
                 }
                 else
                 {
-                    killsByCountLines.Add(($"  {kill.Key}: {kill.Value.Item2} killed on {kill.Value.Item4}", Color.White));
+                    killsByCountLines.Add(($"  {kill.Key}: {kill.Value.Item2} killed on {kill.Value.Item4}", DefaultColor));
                 }
             }
 

--- a/VolvoWrench/Demo stuff/GoldSource/Verification.cs
+++ b/VolvoWrench/Demo stuff/GoldSource/Verification.cs
@@ -29,6 +29,8 @@ namespace VolvoWrench.Demo_Stuff.GoldSource
         public static readonly Color IllegalColor = Color.LightCoral;
         public static readonly Color WarningColor = Color.Yellow;
         public static readonly Color GoodColor = Color.Green;
+        public static readonly Color UnhighlightColor = Color.LightGray;
+        public static readonly Color NameColor = Color.LightSteelBlue;
 
         /// <summary>
         ///     Buffer holds strings to be printed
@@ -38,10 +40,10 @@ namespace VolvoWrench.Demo_Stuff.GoldSource
         /// <summary>
         ///     Dictionaries related to HL100 kill counting
         /// </summary>
-        // Kill Number : UUID, Monster Type, Demo File
-        private Dictionary<int, (string, string, string)> MonsterTypeKillByNumber = new Dictionary<int, (string, string, string)>();
-        // Map : [ UUID, Monster Type, Demo File ]
-        private Dictionary<string, List<(string, string, string)>> MonsterTypeKillByMap = new Dictionary<string, List<(string, string, string)>>();
+        // Kill Number : UUID, Monster Type, Monster Name, Map
+        private Dictionary<int, (string, string, string, string)> MonsterTypeKillByNumber = new Dictionary<int, (string, string, string, string)>();
+        // Map : [ UUID, Monster Type ]
+        private Dictionary<string, List<(string, string)>> MonsterTypeKillByMap = new Dictionary<string, List<(string, string)>>();
 
         /// <summary>
         ///     Default constructor
@@ -200,7 +202,7 @@ namespace VolvoWrench.Demo_Stuff.GoldSource
                 { "c1a2a", new Dictionary<string, int>
                     {
                         {"monster_headcrab", 10},
-                        {"monster_alien_slave", 12},
+                        {"monster_alien_slave", 11},
                         {"monster_barnacle", 2},
                         {"monster_miniturret", 1},
                         {"monster_zombie", 1},
@@ -210,7 +212,7 @@ namespace VolvoWrench.Demo_Stuff.GoldSource
                     {
                         {"monster_headcrab", 13},
                         {"monster_bullchicken", 1},
-                        {"monster_alien_slave", 2},
+                        {"monster_alien_slave", 3},
                         {"monster_zombie", 4},
                     }
                 },
@@ -314,7 +316,7 @@ namespace VolvoWrench.Demo_Stuff.GoldSource
                     {
                         {"monster_human_grunt", 2},
                         {"monster_alien_slave", 7},
-                        {"monster_headcrab", 9},
+                        {"monster_headcrab", 8},
                         {"monster_gargantua", 1},
                     }
                 },
@@ -537,12 +539,11 @@ namespace VolvoWrench.Demo_Stuff.GoldSource
                 { "c2a5d", new Dictionary<string, int>
                     {
                         {"monster_headcrab", 3},
-                        {"monster_human_grunt", 2},
                     }
                 },
                 { "c2a5e", new Dictionary<string, int>
                     {
-                        {"monster_human_grunt", 10},
+                        {"monster_human_grunt", 12},
                         {"monster_sentry", 1},
                         {"func_breakable", 2},
                         {"monster_alien_grunt", 8},
@@ -730,6 +731,31 @@ namespace VolvoWrench.Demo_Stuff.GoldSource
             }
             textBuffer.Append("\n");
 
+            // Dump the kills by number to the textBuffer so it can be cross referenced with the spreadsheet if needed.
+            textBuffer.Append("\nHL100: Kills by number:\n");
+            foreach (var kill in MonsterTypeKillByNumber)
+            {
+                if (!string.IsNullOrEmpty(kill.Value.Item3))
+                {
+                    textBuffer.Append("  " + kill.Key);
+                    textBuffer.Append(": ", UnhighlightColor);
+                    textBuffer.Append(kill.Value.Item2);
+                    textBuffer.Append("'", UnhighlightColor);
+                    textBuffer.Append(kill.Value.Item3, NameColor);
+                    textBuffer.Append("' killed on ", UnhighlightColor);
+                    textBuffer.Append(kill.Value.Item4 + "\n");
+                }
+                else
+                {
+                    textBuffer.Append("  " + kill.Key);
+                    textBuffer.Append(": ", UnhighlightColor);
+                    textBuffer.Append(kill.Value.Item2);
+                    textBuffer.Append(" killed on ", UnhighlightColor);
+                    textBuffer.Append(kill.Value.Item4 + "\n");
+                }
+            }
+            textBuffer.Append("\n");
+
             // Verify they got exactly totalKills kills
             for (int i = 1; i <= totalKills; i++)
             {
@@ -798,7 +824,10 @@ namespace VolvoWrench.Demo_Stuff.GoldSource
             }
             else if (hasWarnings)
             {
-                textBuffer.Append("\nHL100: Verification passed with warnings. Note that report_to_demo commands can sometimes get missed.\n", WarningColor);
+                textBuffer.Append("\nHL100: Verification passed with warnings. " +
+                    "Note that report_to_demo commands can sometimes get missed, " +
+                    "or kills may happen on the other side of level transitions.\n",
+                    WarningColor);
             }
             else
             {
@@ -1869,12 +1898,12 @@ Human readable time:        {TimeSpan.FromSeconds(Df.Sum(x => x.Value.GsDemoInfo
                                         }
 
                                         string killUUID = Guid.NewGuid().ToString();
-                                        MonsterTypeKillByNumber[monsterKillNumber] = (killUUID, monsterType, info.Key);
+                                        MonsterTypeKillByNumber[monsterKillNumber] = (killUUID, monsterType, monsterName, monsterKilledOnMap);
                                         if (!MonsterTypeKillByMap.ContainsKey(monsterKilledOnMap))
                                         {
-                                            MonsterTypeKillByMap.Add(monsterKilledOnMap, new List<(string, string, string)>());
+                                            MonsterTypeKillByMap.Add(monsterKilledOnMap, new List<(string, string)>());
                                         }
-                                        MonsterTypeKillByMap[monsterKilledOnMap].Add((killUUID, monsterType, info.Key));
+                                        MonsterTypeKillByMap[monsterKilledOnMap].Add((killUUID, monsterType));
                                     } catch (Exception e)
                                     {
                                         textBuffer.Append("\tError parsing hl100 report_to_demo in " + info.Key + ": " + e.ToString() + "\n");


### PR DESCRIPTION
- Track and display counts by chapter
- Format three types of counts (by kill number, by map, by chapter) into a table for readability
- Count report_to_demo used as a bound-command as a cheat.

<img width="1207" height="991" alt="Screenshot 2025-09-06 at 2 47 02 PM" src="https://github.com/user-attachments/assets/1f11adf9-eabf-4017-9a3f-387c4bf80e49" />
